### PR TITLE
Add GitHub Actions workflow for backend and frontend builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build Codivus
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Restore backend dependencies
+      run: dotnet restore src/Codivus.sln
+
+    - name: Build backend
+      run: dotnet build src/Codivus.sln --no-restore
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+    - name: Install frontend dependencies
+      run: npm install
+      working-directory: src/Codivus.UI
+    - name: Build frontend
+      run: npm run build
+      working-directory: src/Codivus.UI


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow located in `.github/workflows/build.yml`.

The workflow is configured to:
- Trigger on push events to the `main` branch and on any pull request.
- Run on an `ubuntu-latest` runner.
- Set up .NET Core SDK 8.0.x.
- Restore backend dependencies using `dotnet restore`.
- Build the .NET backend using `dotnet build`.
- Set up Node.js version 18.
- Install frontend dependencies using `npm install` in the `src/Codivus.UI` directory.
- Build the frontend using `npm run build` in the `src/Codivus.UI` directory.